### PR TITLE
Auto Set the Scale and Margins Properly as part of the Print Trigger

### DIFF
--- a/printmechecks/src/App.vue
+++ b/printmechecks/src/App.vue
@@ -6,7 +6,7 @@ import { RouterLink, RouterView } from 'vue-router'
 
     <div class="container">
         <div style="padding-bottom: 20px; padding-top: 20px;">
-            <img  src="@/assets/pmc.png"  />
+            <img id="logo-img" src="@/assets/pmc.png"  />
         </div>
         <ul class="nav nav-tabs">
             <li class="nav-item">

--- a/printmechecks/src/components/CheckPrinter.vue
+++ b/printmechecks/src/components/CheckPrinter.vue
@@ -52,8 +52,7 @@
             </div>
         </div>
         <div class="check-data" style="position: absolute; top: 450px">
-            <div class="alert alert-primary" role="alert">Set scale to Custom 67% when printing. Also set margins to
-                None. <strong>Background does not print.</strong></div>
+            <div class="alert alert-primary" role="alert"><strong>Background does not print.</strong></div>
             <button type="button" style="float: right;" class="btn btn-primary" @click="printCheck">Print (Ctrl + P)</button>
             <form class="row g-3">
                 <div class="col-md-6">

--- a/printmechecks/src/components/CheckPrinter.vue
+++ b/printmechecks/src/components/CheckPrinter.vue
@@ -154,6 +154,14 @@ function printCheck () {
           margin: 0;
           padding: 0;
         }
+        .check-box {
+          background: none !important;
+        }
+        .nav,
+        .check-data,
+        #logo-img {
+          display: none !important;
+        }
       }
     `;
     document.head.appendChild(style);

--- a/printmechecks/src/components/CheckPrinter.vue
+++ b/printmechecks/src/components/CheckPrinter.vue
@@ -228,12 +228,10 @@ onMounted(() => {
     }
     state.check = null
 
-    // Add event listener for Ctrl + P
     window.addEventListener('keydown', handlePrintShortcut);
 });
 
 onUnmounted(() => {
-    // Remove event listener to avoid memory leaks
     window.removeEventListener('keydown', handlePrintShortcut);
 });
 


### PR DESCRIPTION
As I proposed in #3 it'd be best if the scaling and setting to no margin can be handled by the app and there should be no need for the user to mess around with the print dialog settings.

So here's a working code example of code that does it.

I'm pretty new to coding, so you can improve it if needed, but it works for me.