### PR TITLE
Improving print styling

### DIFF
--- a/printmechecks/src/App.vue
+++ b/printmechecks/src/App.vue
@@ -6,7 +6,7 @@ import { RouterLink, RouterView } from 'vue-router'
 
     <div class="container">
         <div style="padding-bottom: 20px; padding-top: 20px;">
-            <img id="logo-img" src="@/assets/pmc.png"  />
+            <img src="@/assets/pmc.png"  />
         </div>
         <ul class="nav nav-tabs">
             <li class="nav-item">

--- a/printmechecks/src/components/CheckPrinter.vue
+++ b/printmechecks/src/components/CheckPrinter.vue
@@ -154,13 +154,27 @@ function printCheck () {
           margin: 0;
           padding: 0;
         }
-        .check-box {
-          background: none !important;
-        }
-        .nav,
-        .check-data,
-        #logo-img {
+        .wrapper > *:not(.check-box) {
           display: none !important;
+        }
+        .check-data {
+            display: none;
+        }
+        .check-box {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          margin: 0;
+          padding: 0px;
+          background-color: white;
+          background: white !important;
+          border: none !important;
+          box-shadow: none !important;
+        }
+        .check-box-print {
+          position: relative;
         }
       }
     `;
@@ -245,19 +259,7 @@ onUnmounted(() => {
 </script>
 
 <style>
-@media print {
-    .check-box {
-        background-color: white;
-        position: fixed;
-        top: 0;
-        left: 0;
-        margin: 0;
-        padding: 0px;
-    }
-    .check-data {
-        display: none;
-    }
-}
+
 label {
     font-weight: bold;
 }


### PR DESCRIPTION
I noticed on the demo site that the cleanup I did wasn't enough (it removed the elements I knew of, but when the site host added an element it remained there on top - if _Background graphics_ is enabled in the Print options):
![image](https://github.com/sktzofrenic/printmechecks/assets/7387839/d5fa147f-321f-4a7c-8116-30a6df12bee5)

So I modified the way it does it, and it sounds better to me.